### PR TITLE
Fix Docker's "exec user process caused no such file or directory" error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,7 @@ FROM golang:latest as builder
 WORKDIR /build
 ADD . /build
 
-RUN go get ./... && \
-    go test ./... && \
-    CGO_ENABLED=0 go build -o aws-s3-proxy ./cmd/
+RUN CGO_ENABLED=0 go build -o aws-s3-proxy ./cmd/
 
 FROM alpine:latest
 LABEL org.opencontainers.image.source=https://github.com/cirruslabs/aws-s3-proxy/

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD . /build
 
 RUN go get ./... && \
     go test ./... && \
-    go build -o aws-s3-proxy ./cmd/
+    CGO_ENABLED=0 go build -o aws-s3-proxy ./cmd/
 
 FROM alpine:latest
 LABEL org.opencontainers.image.source=https://github.com/cirruslabs/aws-s3-proxy/


### PR DESCRIPTION
There's probably a mismatch between dynamic library versions in the `golang:latest` and `alpine:latest` containers. Link statically to avoid this.